### PR TITLE
Correction du texte pour la nouvelle interface de PyCharm Edu

### DIFF
--- a/slides-fr.html
+++ b/slides-fr.html
@@ -580,7 +580,7 @@
 
         1. Pour rouler le code, sélectionnez le symbole de la flèche verte. PyCharm sauvegarde automatiquement votre fichier avant de le rouler.
 
-          ![](framework/img/workshop/pycharm-run.png)
+          ![](framework/img/workshop/pycharm-run.png)  
 
           Vous le retrouverez également dans le menu sous **View > Tool Windows > Run**
 

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -578,14 +578,11 @@
 
         Coder dans un fichier **.py**  consiste à écrire du texte jusqu'à ce que vous soyez prêt(e) à **rouler** le programme en Python.
 
-        1. Pour rouler le code, sélectionnez **Run > Run&hellip;**   
-        PyCharm sauvegarde automatiquement votre fichier avant de le rouler
+        1. Pour rouler le code, sélectionnez le symbole de la flèche verte. PyCharm sauvegarde automatiquement votre fichier avant de le rouler.
 
-          ![](framework/img/workshop/pycharm-run.png)  
+          ![](framework/img/workshop/pycharm-run.png)
 
-        1. Cliquez sur `ex1_hello_world` (une autre fois) dans le menu.
-
-          ![Click to run your program](./framework/img/workshop/run-mini-menu.png)
+          Vous le retrouverez également dans le menu sous **View > Tool Windows > Run**
 
         1. Cliquez dans la fenêtre de la console, tapez votre nom et pressez **Entrée**. Vous devriez voir votre nom.
 


### PR DESCRIPTION
Sur la diapo 27, en français, le texte fait référence à l'ancienne interface graphique de PyCharm Edu. Le texte a été corrigé en anglais mais pas en français. Ce pull request contient la correction appropriée pour le texte en français.

---

On slide 27, for the French slides, the text makes reference to the old user interface for PyCharm Edu. The text was corrected in English but not in French. This pull request contains the appropriate correction for the French text.
